### PR TITLE
Pango update data flags

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -334,9 +334,9 @@ process pangolin {
         path "lineage_report.csv", emit: report
         path "pangolin.version", emit: version
     """
-    if [ "$params.update_data" == "true" ]
+    if [ "$params.update_pango_data" == "true" ]
     then
-      pangolin --update
+      pangolin --update-data
     fi
     
     # set cache for snakemake to prevent permission issuses

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,7 @@ params {
     nextclade_data_tag = null
     nextclade_version = "2.14.0"
     update_data = true
+    update_pango_data = true
     aws_image_prefix = null
     aws_queue = null
     disable_ping = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -224,7 +224,12 @@
                 "update_data": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Update Pangolin and Nextclade data at runtime."
+                    "description": "Update Nextclade data at runtime."
+                },
+                "update__pango_data": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Update Pangolin data at runtime."
                 },
                 "pangolin_options": {
                     "type": "string",


### PR DESCRIPTION
Pull request adds extra flag `--update_pango_data` to control just pango updating. It also changes `pango --update` to `pango --update-data` so that only the data is updated and not the version.

This should fix the current issue where the pipeline crashes due to `pango` trying to self update.